### PR TITLE
Add font-display: swap for font loading

### DIFF
--- a/layouts/main.tsx
+++ b/layouts/main.tsx
@@ -6,7 +6,7 @@ import Head from "../components/head";
 
 const Fonts: React.FC = () => (
   <link
-    href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:700,700italic|Merriweather:300,300italic,700,700italic?display=swap"
+    href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:700,700italic|Merriweather:300,300italic,700,700italic&display=swap"
     rel="stylesheet"
     type="text/css"
   />

--- a/layouts/main.tsx
+++ b/layouts/main.tsx
@@ -6,7 +6,7 @@ import Head from "../components/head";
 
 const Fonts: React.FC = () => (
   <link
-    href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:700,700italic|Merriweather:300,300italic,700,700italic"
+    href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:700,700italic|Merriweather:300,300italic,700,700italic?display=swap"
     rel="stylesheet"
     type="text/css"
   />


### PR DESCRIPTION
https://web.dev/font-display/ explains that `font-display: swap` can help avoid flash-of-invisible-text in most modern browsers. Supported automatically by Google's font loader url with this query parameter.